### PR TITLE
Colour constant should be of Colour type instead of int type

### DIFF
--- a/wx-stubs/__init__.pyi
+++ b/wx-stubs/__init__.pyi
@@ -4422,9 +4422,9 @@ currently selected font.
 
 
 
-BLACK: int
+BLACK: 'Colour'
 
-WHITE: int
+WHITE: 'Colour'
 
 ODDEVEN_RULE: int
 
@@ -46010,15 +46010,15 @@ DEFAULT: int
 
 wxEVT_COMMAND_BUTTON_CLICKED: int
 
-RED: int
+RED: 'Colour'
 
-YELLOW: int
+YELLOW: 'Colour'
 
-BLUE: int
+BLUE: 'Colour'
 
-GREEN: int
+GREEN: 'Colour'
 
-CYAN: int
+CYAN: 'Colour'
 
 OPEN: int
 


### PR DESCRIPTION
All of the Colour constants are defined as type[Colour] in [wx](https://docs.wxwidgets.org/3.0/colour_8h.html#a98125a3b5ab1f7bc8dbc7a62e329f142) and should be defined as well as wx.Colour type in the __init__.pyi file.