### PR TITLE
overrides.py: Add Scrolled class

### DIFF
--- a/generator/overrides.py
+++ b/generator/overrides.py
@@ -227,6 +227,9 @@ OVERRIDES: dict[str, dict[str, Any]] = {
             "kind": "'StockPreferencesPage.Kind'"
         }
     },
+    "wx.Scrolled": {
+        "superClass": ["wx.Window"],
+    },
     "wx.grid.Grid": {
         "superClass": ["wx.Scrolled"],
     }


### PR DESCRIPTION
After adding Grid as a subclass of Scrolled, mypy can't recognize that the Scrolled Class is a subclass of Window. Adding it so that the inheritance is clear for mypy.