### PR TITLE
Use /bin/sh in run.sh shebang

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 poetry run python -m generator
 poetry run isort wx-stubs
 poetry run yapf -i -p -r wx-stubs


### PR DESCRIPTION
This script should be compatible with any POSIX-compatible shell, and not just bash. As such, don't require users to have bash installed to run this.