### PR TITLE
markdownify docstring

### DIFF
--- a/generator/parser.py
+++ b/generator/parser.py
@@ -54,7 +54,7 @@ class Parser:
 			return
 
 		# Process the HTML
-		soup = BeautifulSoup(r.text, 'html.parser')
+		soup = BeautifulSoup(r.content, 'html.parser')
 		if soup is None:
 			self.logger.error("This page '%s' doesnt work!" % url)
 			return
@@ -214,7 +214,7 @@ class Parser:
 			}
 
 			# Find the name
-			methodName: str = methodTag.find_all("dt", limit=1)[0].get_text()[:-2].strip()
+			methodName: str = methodTag.find_all("dt", limit=1)[0].get_text()[:-1].strip()
 			methodType["name"] = methodName
 
 			# Find the docstring
@@ -366,7 +366,7 @@ class Parser:
 			}
 
 			# Find the name
-			literalName: str = literalTag.find_all("dt", limit=1)[0].get_text()[:-2].strip()
+			literalName: str = literalTag.find_all("dt", limit=1)[0].get_text()[:-1].strip()
 			literalType["name"] = literalName
 
 			# Find the docstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ generate-setup-file = true
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
+markdownify = "^0.12.1"
 
 [tool.poetry.dev-dependencies]
 requests = "^2.28.2"


### PR DESCRIPTION
In most cases docstring contains only one sentence and a link to the documentation. 

I've tried to `markdownify` relevant part of the documentation and put it in the docstring. 
It seems to be very useful especialy in cases when parameter types are not parsed.  

Pull request #28 (fix encoding) is necesary for this.