### PR TITLE
Add wx.grid.GRID_AUTOSIZE constant

### DIFF
--- a/generator/extras.py
+++ b/generator/extras.py
@@ -1022,6 +1022,15 @@ lObj = {
 EXTRA_KNOWN_ITEMS.append(lObj)
 lObj = {
     "type": TypingType.LITERAL,
+    "name": "GRID_AUTOSIZE",
+    "moduleName": "wx",
+    "returnType": "int",
+    "docstring": "",
+    "source": "https://docs.wxpython.org/wx.grid.Grid.html#wx.grid.Grid.SetColLabelSize",
+}
+EXTRA_KNOWN_ITEMS.append(lObj)
+lObj = {
+    "type": TypingType.LITERAL,
     "name": "GRID_VALUE_STRING",
     "moduleName": "wx.grid",
     "returnType": "str",


### PR DESCRIPTION
This constant is missing from the generated stubs, although it is mentioned in the docs and present in the wxPython source code:

https://docs.wxpython.org/wx.grid.Grid.html#wx.grid.Grid.SetColLabelSize
https://docs.wxpython.org/wx.grid.Grid.html#wx.grid.Grid.SetRowLabelSize

It is mentioned in the change log here: https://github.com/wxWidgets/Phoenix/blob/3901d05d40a5d70efb696ea62b1d21be7a8d7063/CHANGES.rst#L1155